### PR TITLE
Added CHF as second exchange rate and the option to hide second exchange rate at all

### DIFF
--- a/server/.env.sample
+++ b/server/.env.sample
@@ -18,4 +18,6 @@ DISPLAY_FALLBACK_RATES=true
 
 # Shall a second exchange rate be shown?
 DISPLAY_SECOND_EXCHANGE_RATE=true
+# choose second exchange rate to show (supported: EUR, CHF)
+SECOND_EXCHANGE_RATE=EUR
 

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -15,3 +15,7 @@ DISPLAY_SERVER_PORT=3030
 # Shall the fallbacks be used?
 DISPLAY_FALLBACK_BLOCK=true
 DISPLAY_FALLBACK_RATES=true
+
+# Shall a second exchange rate be shown?
+DISPLAY_SECOND_EXCHANGE_RATE=true
+

--- a/server/data.sh
+++ b/server/data.sh
@@ -27,17 +27,31 @@ if [[ "${BTCPAY_API_TOKEN}" && "${BTCPAY_HOST}" ]]; then
   usdrate=$($tor curl -s -f -H "Authorization: Basic $BTCPAY_API_TOKEN" $BTCPAY_HOST/rates/BTC/USD | jq -r '.data.rate')
   
   if [[ ${DISPLAY_SECOND_EXCHANGE_RATE} = true ]]; then
-    eurrate=$($tor curl -s -f -H "Authorization: Basic $BTCPAY_API_TOKEN" $BTCPAY_HOST/rates/BTC/EUR | jq -r '.data.rate')
+    if [[ "${SECOND_EXCHANGE_RATE}" = "EUR" ]]; then
+      eurrate=$($tor curl -s -f -H "Authorization: Basic $BTCPAY_API_TOKEN" $BTCPAY_HOST/rates/BTC/EUR | jq -r '.data.rate')
+    fi
+    if [[ "${SECOND_EXCHANGE_RATE}" = "CHF" ]]; then
+      chfrate=$($tor curl -s -f -H "Authorization: Basic $BTCPAY_API_TOKEN" $BTCPAY_HOST/rates/BTC/CHF | jq -r '.data.rate')
+    fi
   fi
 fi
-if [[ "${usdrate}" = "" && ${DISPLAY_FALLBACK_RATES} = true ]]; then
-  usdrate=$($tor curl -s -f https://api.kraken.com/0/public/Ticker\?pair=XBTUSD | jq -r '.result.XXBTZUSD.c[0] // "[]"')
-fi
-if [[ "${eurrate}" = "" && ${DISPLAY_FALLBACK_RATES} = true && ${DISPLAY_SECOND_EXCHANGE_RATE} = true ]]; then
-  eurrate=$($tor curl -s -f https://api.kraken.com/0/public/Ticker\?pair=XBTEUR | jq -r '.result.XXBTZEUR.c[0] // "[]"')
+
+if [[ ${DISPLAY_FALLBACK_RATES} = true ]]; then
+  if [[ "${usdrate}" = "" ]]; then
+    usdrate=$($tor curl -s -f https://api.kraken.com/0/public/Ticker\?pair=XBTUSD | jq -r '.result.XXBTZUSD.c[0] // "[]"')
+  fi
+  
+  if [[ ${DISPLAY_SECOND_EXCHANGE_RATE} = true ]]; then
+    if [[ "${eurrate}" = "" && "${SECOND_EXCHANGE_RATE}" = "EUR" ]]; then
+      eurrate=$($tor curl -s -f https://api.kraken.com/0/public/Ticker\?pair=XBTEUR | jq -r '.result.XXBTZEUR.c[0] // "[]"')
+    fi
+    if [[ "${chfrate}" = "" && "${SECOND_EXCHANGE_RATE}" = "CHF" ]]; then
+      chfrate=$($tor curl -s -f https://api.kraken.com/0/public/Ticker?pair=XBTCHF | jq -r '.result.XBTCHF.c[0] // "[]"')
+    fi
+  fi
 fi
 
-rates=$(jo -p -a $(jo rate="$usdrate" code="USD") $(jo rate="$eurrate" code="EUR"))
+rates=$(jo -p -a $(jo rate="$usdrate" code="USD") $(jo rate="$eurrate" code="EUR") $(jo rate="$chfrate" code="CHF"))
 
 # Bitcoin Quotes
 quote=$( $tor curl -s -f https://www.bitcoin-quotes.com/quotes/random.json 2> /dev/null || echo "null")

--- a/server/data.sh
+++ b/server/data.sh
@@ -25,18 +25,19 @@ fi
 # Fetch rates using custom BTCPay or Kraken as fallback
 if [[ "${BTCPAY_API_TOKEN}" && "${BTCPAY_HOST}" ]]; then
   usdrate=$($tor curl -s -f -H "Authorization: Basic $BTCPAY_API_TOKEN" $BTCPAY_HOST/rates/BTC/USD | jq -r '.data.rate')
-  eurrate=$($tor curl -s -f -H "Authorization: Basic $BTCPAY_API_TOKEN" $BTCPAY_HOST/rates/BTC/EUR | jq -r '.data.rate')
+  
+  if [[ ${DISPLAY_SECOND_EXCHANGE_RATE} = true ]]; then
+    eurrate=$($tor curl -s -f -H "Authorization: Basic $BTCPAY_API_TOKEN" $BTCPAY_HOST/rates/BTC/EUR | jq -r '.data.rate')
+  fi
 fi
 if [[ "${usdrate}" = "" && ${DISPLAY_FALLBACK_RATES} = true ]]; then
   usdrate=$($tor curl -s -f https://api.kraken.com/0/public/Ticker\?pair=XBTUSD | jq -r '.result.XXBTZUSD.c[0] // "[]"')
 fi
-if [[ "${eurrate}" = "" && ${DISPLAY_FALLBACK_RATES} = true ]]; then
+if [[ "${eurrate}" = "" && ${DISPLAY_FALLBACK_RATES} = true && ${DISPLAY_SECOND_EXCHANGE_RATE} = true ]]; then
   eurrate=$($tor curl -s -f https://api.kraken.com/0/public/Ticker\?pair=XBTEUR | jq -r '.result.XXBTZEUR.c[0] // "[]"')
 fi
 
-if [[ "${usdrate}" && "${eurrate}" ]]; then
-  rates=$(jo -p -a $(jo rate="$usdrate" code="USD") $(jo rate="$eurrate" code="EUR"))
-fi
+rates=$(jo -p -a $(jo rate="$usdrate" code="USD") $(jo rate="$eurrate" code="EUR"))
 
 # Bitcoin Quotes
 quote=$( $tor curl -s -f https://www.bitcoin-quotes.com/quotes/random.json 2> /dev/null || echo "null")

--- a/server/public/style.css
+++ b/server/public/style.css
@@ -53,6 +53,9 @@ body {
 .price--euro {
   margin-left: 1rem;
 }
+.price--chf {
+  margin-left: 1rem;
+}
 .price--sats {
   position: absolute;
   top: 645px;

--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -2,8 +2,9 @@ extends _layout
 block content
   - const usdRate = rates && rates.find(rate => rate.code === 'USD')
   - const eurRate = rates && rates.find(rate => rate.rate != null && rate.code === 'EUR')
+  - const chfRate = rates && rates.find(rate => rate.rate != null && rate.code === 'CHF')
   - const displayQuote = quote && quote.body.length < 220
-  - const displayEuro = eurRate && (!displayQuote || quote && quote.body.length < 115)
+  - const displaySecondRate = (eurRate || chfRate) && (!displayQuote || quote && quote.body.length < 115)
   .bg
   .info
     if usdRate
@@ -14,9 +15,13 @@ block content
     h1!= blockcount || '&nbsp;'
 
     if eurRate
-      h3.price.price--euro(class=displayEuro ? null : 'price--hidden')
+      h3.price.price--euro(class=displaySecondRate ? null : 'price--hidden')
         span.curr €
         span.rate= Math.round(eurRate.rate)
+    if chfRate
+      h3.price.price--chf(class=displaySecondRate ? null : 'price--hidden')
+        span.curr CHF
+        span.rate= Math.round(chfRate.rate)
 
   if displayQuote
     blockquote

--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -1,7 +1,7 @@
 extends _layout
 block content
   - const usdRate = rates && rates.find(rate => rate.code === 'USD')
-  - const eurRate = rates && rates.find(rate => rate.code === 'EUR')
+  - const eurRate = rates && rates.find(rate => rate.rate != null && rate.code === 'EUR')
   - const displayQuote = quote && quote.body.length < 220
   - const displayEuro = eurRate && (!displayQuote || quote && quote.body.length < 115)
   .bg


### PR DESCRIPTION
This feature lets you choose which second exchange rate to show on the kindle display (EUR or CHF) and also has an option to turn off showing a second exchange rate at all. If you want the software to behave as before (showing EUR as second rate) you have to add these lines to your ".env" file (see ".env.sample" for explanation):

DISPLAY_SECOND_EXCHANGE_RATE=true
SECOND_EXCHANGE_RATE=EUR

@dennisreimann:  Please test the BTCPay code in "data.sh"! Because I have no BTCPay server running, I couldn't test it (is this the correct url to get the CHF exchange rate from BTCPay? I could only guess:)