### PR TITLE
changed the visual representation of the battery level

### DIFF
--- a/kindle/mnt/base-us/update.sh
+++ b/kindle/mnt/base-us/update.sh
@@ -5,6 +5,7 @@ FILE=display.png
 
 savePower=false
 batteryLevel=$(lipc-get-prop com.lab126.powerd battLevel)
+batteryBar=$(($batteryLevel/10))
 now=$(date +'%F %R')
 
 cd "$(dirname "$0")"
@@ -26,10 +27,20 @@ fi
 
 eips 0 0 "$now"
 
-# display low battery level
-if [ $batteryLevel -le 25 ]; then
-  eips 47 0 "$batteryLevel%"
-fi
+# display battery level
+case "$batteryBar" in
+  0)  eips 38 0 "|-----$batteryLevel--->|" ;;
+  1)  eips 38 0 "|----$batteryLevel-->=|" ;;
+  2)  eips 38 0 "|----$batteryLevel->==|" ;;
+  3)  eips 38 0 "|----$batteryLevel>===|" ;;
+  4)  eips 38 0 "|----$batteryLevel====|" ;;
+  5)  eips 38 0 "|----$batteryLevel====|" ;;
+  6)  eips 38 0 "|--->$batteryLevel====|" ;;
+  7)  eips 38 0 "|-->=$batteryLevel====|" ;;
+  8)  eips 38 0 "|->==$batteryLevel====|" ;;
+  9)  eips 38 0 "|>===$batteryLevel====|" ;;
+  10)  eips 38 0 "|====100===|" ;;
+esac
 
 if [ "$savePower" = true ]; then
   # power down networking

--- a/kindle/mnt/base-us/update.sh
+++ b/kindle/mnt/base-us/update.sh
@@ -5,7 +5,6 @@ FILE=display.png
 
 savePower=false
 batteryLevel=$(lipc-get-prop com.lab126.powerd battLevel)
-batteryBar=$(($batteryLevel/10))
 now=$(date +'%F %R')
 
 cd "$(dirname "$0")"
@@ -28,19 +27,21 @@ fi
 eips 0 0 "$now"
 
 # display battery level
-case "$batteryBar" in
-  0)  eips 38 0 "|-----$batteryLevel--->|" ;;
-  1)  eips 38 0 "|----$batteryLevel-->=|" ;;
-  2)  eips 38 0 "|----$batteryLevel->==|" ;;
-  3)  eips 38 0 "|----$batteryLevel>===|" ;;
-  4)  eips 38 0 "|----$batteryLevel====|" ;;
-  5)  eips 38 0 "|----$batteryLevel====|" ;;
-  6)  eips 38 0 "|--->$batteryLevel====|" ;;
-  7)  eips 38 0 "|-->=$batteryLevel====|" ;;
-  8)  eips 38 0 "|->==$batteryLevel====|" ;;
-  9)  eips 38 0 "|>===$batteryLevel====|" ;;
-  10)  eips 38 0 "|====100===|" ;;
-esac
+if [ $batteryLevel -lt 100 ]; then
+  batteryBar=$(($batteryLevel/10))
+  case "$batteryBar" in
+    0)  eips 38 0 "|-----$batteryLevel--->|" ;;
+    1)  eips 38 0 "|----$batteryLevel-->=|" ;;
+    2)  eips 38 0 "|----$batteryLevel->==|" ;;
+    3)  eips 38 0 "|----$batteryLevel>===|" ;;
+    4)  eips 38 0 "|----$batteryLevel====|" ;;
+    5)  eips 38 0 "|----$batteryLevel====|" ;;
+    6)  eips 38 0 "|--->$batteryLevel====|" ;;
+    7)  eips 38 0 "|-->=$batteryLevel====|" ;;
+    8)  eips 38 0 "|->==$batteryLevel====|" ;;
+    9)  eips 38 0 "|>===$batteryLevel====|" ;;
+  esac
+fi
 
 if [ "$savePower" = true ]; then
   # power down networking


### PR DESCRIPTION
Please take a look on this commit that changes the way the battery level is shown. The problem with the old indicator was, that it should show the battery level (if < 25) as a number in percent. The problem: the kindle 4 can not show the percent sign. This looked strange. See for more details:

https://www.mobileread.com/forums/showthread.php?t=278982

I wanted to change that into a visual representation drawing two rectangles on the screen, showing how full the battery is. Unfortunatelly also this command does not work on a kindle 4 (argh!). See:

https://wiki.mobileread.com/wiki/Eips

Now I am using characters showing a somewhat visual representation (enriched with the number):

|----25->==|

Only pull it, if you like it.

Because I only want to call the drawing command once, I used this odd looking switch-case structure instead of a fancy loop to generate the characters.
