### PR TITLE
Allow mempool API URL overrides

### DIFF
--- a/server/.env.sample
+++ b/server/.env.sample
@@ -24,5 +24,10 @@ DISPLAY_RATE2="EUR"
 DISPLAY_FALLBACK_BLOCK=true
 DISPLAY_FALLBACK_RATES=true
 
+# Optional mempool-compatible API overrides.
+# DISPLAY_MEMPOOL_FEES_URL="https://mempool.space/api/v1/fees/recommended"
+# DISPLAY_MEMPOOL_BLOCKS_URL="https://mempool.space/api/v1/fees/mempool-blocks"
+# DISPLAY_MEMPOOL_LIGHTNING_URL="https://mempool.space/api/v1/lightning/statistics/latest"
+
 # Display settings: quote (default), fees, lightning, stats, random
 DISPLAY_THEME="quote"

--- a/server/data.sh
+++ b/server/data.sh
@@ -51,9 +51,12 @@ fi
 quote=$($tor curl -s -f https://www.bitcoin-quotes.com/quotes/random.json 2> /dev/null || echo "null")
 
 # Mempool Stats
-fees=$($tor curl -s -f https://mempool.space/api/v1/fees/recommended 2> /dev/null || echo "null")
-mempoolblocks=$($tor curl -s -f https://mempool.space/api/v1/fees/mempool-blocks 2> /dev/null || echo "null")
-lightning=$($tor curl -s -f https://mempool.space/api/v1/lightning/statistics/latest 2> /dev/null || echo "null")
+MEMPOOL_FEES_URL="${DISPLAY_MEMPOOL_FEES_URL:-https://mempool.space/api/v1/fees/recommended}"
+MEMPOOL_BLOCKS_URL="${DISPLAY_MEMPOOL_BLOCKS_URL:-https://mempool.space/api/v1/fees/mempool-blocks}"
+MEMPOOL_LIGHTNING_URL="${DISPLAY_MEMPOOL_LIGHTNING_URL:-https://mempool.space/api/v1/lightning/statistics/latest}"
+fees=$($tor curl -s -f "$MEMPOOL_FEES_URL" 2> /dev/null || echo "null")
+mempoolblocks=$($tor curl -s -f "$MEMPOOL_BLOCKS_URL" 2> /dev/null || echo "null")
+lightning=$($tor curl -s -f "$MEMPOOL_LIGHTNING_URL" 2> /dev/null || echo "null")
 
 # JSON
 jo -p date="$now" blockcount="$blockcount" rate1=$(jo rate="$rate1" moscow="$moscow1" code="$DISPLAY_RATE1") rate2=$(jo rate="$rate2" moscow="$moscow2" code="$DISPLAY_RATE2") quote="$quote" fees="$fees" mempoolblocks="$mempoolblocks" lightning="$lightning"  > $dir/data.json


### PR DESCRIPTION
This keeps the existing mempool.space defaults, but lets users override the mempool-related API URLs from `.env`:

- `DISPLAY_MEMPOOL_FEES_URL`
- `DISPLAY_MEMPOOL_BLOCKS_URL`
- `DISPLAY_MEMPOOL_LIGHTNING_URL`

I work on Satoshi API, and the concrete use case is pointing `DISPLAY_MEMPOOL_BLOCKS_URL` at a compatible projected-block source such as:

`https://bitcoinsapi.com/api/v1/compat/mempool/fees/mempool-blocks`

This is intentionally generic: it also works for self-hosted mempool.space or other compatible endpoints, and it does not change the default behavior.

Verification:
- `git diff --check` passed.
- `bash -n server/data.sh` was not useful in this Windows Git Bash checkout because the current HEAD version also reports `syntax error: unexpected end of file` when piped through `bash -n`.